### PR TITLE
Fix config, add getSelectedIndexes

### DIFF
--- a/library/src/main/java/fisk/chipcloud/ChipCloud.java
+++ b/library/src/main/java/fisk/chipcloud/ChipCloud.java
@@ -3,10 +3,12 @@ package fisk.chipcloud;
 import android.content.Context;
 import android.graphics.Typeface;
 import android.graphics.drawable.StateListDrawable;
+import android.support.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import eu.fiskur.chipcloud.R;
@@ -36,16 +38,14 @@ public class ChipCloud implements View.OnClickListener{
   private boolean ignoreAutoChecks = false;
 
   public ChipCloud(Context context, ViewGroup layout){
-    this.context = context;
-    this.layout = layout;
-    selectMode = SelectMode.multi;
+    this(context, layout, new ChipCloudConfig());
   }
 
-  public ChipCloud(Context context, ViewGroup layout, ChipCloudConfig config) {
+  public ChipCloud(Context context, ViewGroup layout, @NonNull ChipCloudConfig config) {
     this.context = context;
     this.layout = layout;
-    selectMode = config.selectMode;
     this.config = config;
+    selectMode = config.selectMode;
   }
 
   public void setListener(ChipListener chipListener){
@@ -122,6 +122,21 @@ public class ChipCloud implements View.OnClickListener{
       default:
         //
     }
+  }
+
+  public int[] getSelectedIndexes(){
+    final int childCount = layout.getChildCount();
+    final ArrayList<Integer> selectedIndexes = new ArrayList<>(childCount);
+    for(int i = 0; i < childCount; i++){
+      if(((ToggleChip) layout.getChildAt(i)).isChecked()) {
+        selectedIndexes.add(i);
+      }
+    }
+    final int[] result = new int[selectedIndexes.size()];
+    for(int i = 0; i < result.length; i++){
+      result[i] = selectedIndexes.get(i);
+    }
+    return result;
   }
 
   public String getLabel(int index){

--- a/library/src/main/java/fisk/chipcloud/ChipCloudConfig.java
+++ b/library/src/main/java/fisk/chipcloud/ChipCloudConfig.java
@@ -1,14 +1,16 @@
 package fisk.chipcloud;
 
 import android.graphics.Typeface;
+import android.support.annotation.ColorInt;
 
 public class ChipCloudConfig {
 
+  public final static int UNSPECIFIED = -1;
   public Typeface typeface = null;
-  public int checkedChipColor = -1;
-  public int uncheckedChipColor = -1;
-  public int checkedTextColor = -1;
-  public int uncheckedTextColor = -1;
+  public @ColorInt int checkedChipColor = UNSPECIFIED;
+  public @ColorInt int uncheckedChipColor = UNSPECIFIED;
+  public @ColorInt int checkedTextColor = UNSPECIFIED;
+  public @ColorInt int uncheckedTextColor = UNSPECIFIED;
   public ChipCloud.SelectMode selectMode = ChipCloud.SelectMode.multi;
   public boolean useInsetPadding = false;
 
@@ -20,22 +22,22 @@ public class ChipCloudConfig {
     return this;
   }
 
-  public ChipCloudConfig checkedChipColor(int checkedChipColor){
+  public ChipCloudConfig checkedChipColor(@ColorInt int checkedChipColor){
     this.checkedChipColor = checkedChipColor;
     return this;
   }
 
-  public ChipCloudConfig uncheckedChipColor(int uncheckedChipColor){
+  public ChipCloudConfig uncheckedChipColor(@ColorInt int uncheckedChipColor){
     this.uncheckedChipColor = uncheckedChipColor;
     return this;
   }
 
-  public ChipCloudConfig checkedTextColor(int checkedTextColor){
+  public ChipCloudConfig checkedTextColor(@ColorInt int checkedTextColor){
     this.checkedTextColor = checkedTextColor;
     return this;
   }
 
-  public ChipCloudConfig uncheckedTextColor(int uncheckedTextColor){
+  public ChipCloudConfig uncheckedTextColor(@ColorInt int uncheckedTextColor){
     this.uncheckedTextColor = uncheckedTextColor;
     return this;
   }

--- a/library/src/main/java/fisk/chipcloud/ConfigHelper.java
+++ b/library/src/main/java/fisk/chipcloud/ConfigHelper.java
@@ -1,28 +1,42 @@
 package fisk.chipcloud;
 
 import android.graphics.PorterDuff;
+import android.support.annotation.NonNull;
+
+import static fisk.chipcloud.ChipCloudConfig.UNSPECIFIED;
 
 class ConfigHelper {
 
-  static void initialise(ToggleChip toggleChip, ChipCloudConfig config){
-    if(config != null){
-        toggleChip.getBackground().setColorFilter(config.uncheckedChipColor, PorterDuff.Mode.SRC);
-        toggleChip.setTextColor(config.uncheckedTextColor);
-      if(config.typeface != null){
-        toggleChip.setTypeface(config.typeface);
-      }
+  static void initialise(ToggleChip toggleChip, @NonNull ChipCloudConfig config){
+    setUncheckedColors(toggleChip, config);
+    if(config.typeface != null){
+      toggleChip.setTypeface(config.typeface);
     }
   }
 
-  static void update(ToggleChip toggleChip, ChipCloudConfig config){
-    if(config != null) {
-      if (toggleChip.isChecked()) {
-          toggleChip.getBackground().setColorFilter(config.checkedChipColor, PorterDuff.Mode.SRC);
-          toggleChip.setTextColor(config.checkedTextColor);
-      } else {
-          toggleChip.getBackground().setColorFilter(config.uncheckedChipColor, PorterDuff.Mode.SRC);
-          toggleChip.setTextColor(config.uncheckedTextColor);
-      }
+  static void update(ToggleChip toggleChip, @NonNull ChipCloudConfig config){
+    if(toggleChip.isChecked()){
+      setCheckedColors(toggleChip, config);
+    }else{
+      setUncheckedColors(toggleChip, config);
+    }
+  }
+
+  static private void setUncheckedColors(ToggleChip toggleChip, @NonNull ChipCloudConfig config){
+    if(config.uncheckedChipColor != UNSPECIFIED){
+      toggleChip.getBackground().setColorFilter(config.uncheckedChipColor, PorterDuff.Mode.SRC);
+    }
+    if(config.uncheckedTextColor != UNSPECIFIED) {
+      toggleChip.setTextColor(config.uncheckedTextColor);
+    }
+  }
+
+  static private void setCheckedColors(ToggleChip toggleChip, @NonNull ChipCloudConfig config){
+    if(config.checkedChipColor != UNSPECIFIED){
+      toggleChip.getBackground().setColorFilter(config.checkedChipColor, PorterDuff.Mode.SRC);
+    }
+    if(config.checkedTextColor != UNSPECIFIED){
+      toggleChip.setTextColor(config.checkedTextColor);
     }
   }
 }


### PR DESCRIPTION
This could be split into 2 PRs (one for the config fix, one for the additional method), let me know if you would like me to do that.
I'm also not really sure about the code style to follow as it is not consistent across the codebase.

## Goal
1. Fix crash when using the constructor that doesn't take a Config object.
2. Prevent non specified values of a Config object to override values specified by XML.
3. Add ability to retrieve the list of selected items.

## Solution
For (1), in order to avoid a lot of null checks (and crashes, as we can see), let's just provide a config object no matter what when instantiating a cloud.

For (2), the problem was that everything that the end user of the library would provide by XML would be overridden by the values of the Config object, even though no values were specified by the user. With this fix, only values explicitly set in the config will be applied.

Note: for the Config object, it would be nice if we could adopt the `Builder` pattern.

For (3), I just needed a way to retrieve the list of all currently selected indexes, so added a method that does that.

Let me know what you think and thanks for this library.